### PR TITLE
[MODIFY] kernel files copy in rootfs & change '/lib/modules/../build' softlink

### DIFF
--- a/kernel-utils/boot
+++ b/kernel-utils/boot
@@ -96,14 +96,6 @@ fi
 echo "Removing existing kernel modules..."
 sudo rm -rf ${rootfs}/lib/modules/*
 
-if test "${copy_modules_to_rootfs}x" = "yx"; then
-    (
-      cd ${srcdir}/${kernel}
-      echo "Copying kernel modules to rootfs..."
-      sudo make INSTALL_MOD_PATH=${rootfs} modules_install
-    )
-fi
-
 if test "${copy_samples_to_rootfs}x" = "yx"; then
     (
       cd ${samplesdir}
@@ -111,6 +103,18 @@ if test "${copy_samples_to_rootfs}x" = "yx"; then
 
       echo "Copying sample kernel modules to rootfs..."
       sudo KERNEL_PATH=${srcdir}/${kernel} INSTALL_MOD_PATH=${rootfs} make install
+    )
+fi
+
+if test "${copy_modules_to_rootfs}x" = "yx"; then
+    (
+      #cd ${srcdir}/${kernel}
+      #echo "Copying kernel modules to rootfs..."
+      #sudo make INSTALL_MOD_PATH=${rootfs} modules_install
+      sudo apt-get -y install rsync
+      sudo rsync -av --exclude='cscope*' --exclude='tags' --exclude='vmlinux*' ${srcdir}/${kernel} ${rootfs}/usr/src/
+      echo "Install kernel modules to rootfs..."
+      sudo chroot ${rootfs} make -C /usr/src/${kernel}/ modules_install
     )
 fi
 

--- a/kernel-utils/config/env.sh
+++ b/kernel-utils/config/env.sh
@@ -28,7 +28,7 @@ labdir=labs
 projdir=project
 
 hostname=sce394_vm
-rootfs_size=2048m
+rootfs_size=4608m
 memory=512m
 
 # Option to compile and copy kernel modules to rootfs


### PR DESCRIPTION
- kernel 모듈 빌드를 위해 vm이 아닌 docker에서 수행해야하는 절차를 해결하였습니다.
- kernel-utils/src/linux-XX/ 내의 커널 파일 복사를 위해 rootfs.img의 크기를 4608m로 늘렸습니다. ( 좀 더 작은 크기로 했을 떄 될 때도 있지만 종종 용량 문제로 에러가 발생하였습니다.)
- (Before)
<img width="1406" alt="image" src="https://github.com/csl-ajou/sce394-linux-kernel-labs/assets/78012131/5e661639-a397-4506-bc53-80a461fb7cab">

- (After)
![image](https://github.com/csl-ajou/sce394-linux-kernel-labs/assets/78012131/67bc2660-bf3a-4514-b606-997bd463ffe2)
